### PR TITLE
Chore/trivy scan updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
 jobs:
   build-for-test:
     docker:
-      - image: node:18.16.1-bullseye-slim
+      - image: node:20.16.0-bookworm-slim
     steps:
       - checkout
       - run:
@@ -36,7 +36,7 @@ jobs:
             - ./node_modules
   test:
     docker:
-      - image: node:18.16.1-bullseye-slim
+      - image: node:20.16.0-bookworm-slim
     steps:
       - attach_workspace:
           at: ./
@@ -47,7 +47,7 @@ jobs:
           command: npx --no-install jest --ci --runInBand --bail --silent --coverage --projects jest.config.js jest.config.jsdom.js
   lint:
     docker:
-      - image: node:18.16.1-bullseye-slim
+      - image: node:20.16.0-bookworm-slim
     steps:
       - attach_workspace:
           at: ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,9 @@ jobs:
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
       - run:
           name: Scan the local image with trivy
-          command: trivy image --exit-code 0 --no-progress cica/cica-repo-dev
+          command: |
+            trivy image --exit-code 0 --severity MEDIUM,HIGH --no-progress cica/cica-repo-dev
+            trivy image --exit-code 1 --severity CRITICAL --no-progress --show-suppressed cica/cica-repo-dev --vex trivy.openvex.json
       - run:
           name: Archive Docker Image
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # lets start from an image that already has nodejs installed
 # https://snyk.io/blog/choosing-the-best-node-js-docker-image/
-FROM node:18.16.1-bookworm-slim as base
+FROM node:20.16.0-bookworm-slim as base
 RUN groupadd -g 1014 dc_user \
     && useradd -rm -d /usr/src/app -u 1015 -g dc_user dc_user
 USER dc_user

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "7.5.13",
+    "version": "7.5.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "7.5.13",
+            "version": "7.5.14",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "7.5.13",
+    "version": "7.5.14",
     "engines": {
         "npm": ">=9.5.0",
         "node": ">=18.16.1"

--- a/trivy.openvex.json
+++ b/trivy.openvex.json
@@ -1,0 +1,17 @@
+{
+    "@context": "https://openvex.dev/ns/v0.2.0",
+    "@id": "https://openvex.dev/docs/public/vex-2e67563e128250cbcb3e98930df948dd053e43271d70dc50cfa22d57e03fe96f",
+    "author": "CICA DEV TEAM",
+    "timestamp": "2024-08-26T13:07:16.853479631-06:00",
+    "version": 1,
+    "statements": [
+        {
+            "vulnerability": {"name": "CVE-2023-45853"},
+            "products": [
+                {"@id": "pkg:deb/debian/zlib1g@1.2.13.dfsg-1?arch=amd64&distro=debian-12.6&epoch=1"}
+            ],
+            "status": "not_affected",
+            "justification": "vulnerable_code_not_in_execute_path"
+        }
+    ]
+}


### PR DESCRIPTION
- switch on critical trivy vulnerability scanning
- add VEX file to suppress CVE CVE-2023-45853
- bump node container to 20.16.0-bookworm-slim