### PR TITLE
Add missing env defs to staging deploy.yml

### DIFF
--- a/kube_deploy/Stag/deploy.yml
+++ b/kube_deploy/Stag/deploy.yml
@@ -84,6 +84,21 @@ spec:
                 secretKeyRef:
                   name: shared-secrets
                   key: session_duration
+            - name: CW_GOVUK_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_govuk_client_id
+            - name: CW_GOVUK_ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_govuk_issuer_url
+            - name: CW_GOVUK_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cica-web-secrets
+                  key: cw_govuk_private_key
             - name: CW_INTERNAL_IP
               valueFrom:
                 secretKeyRef:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "7.5.20",
+    "version": "7.5.21",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "7.5.20",
+            "version": "7.5.21",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "7.5.20",
+    "version": "7.5.21",
     "engines": {
         "npm": ">=10.8.2",
         "node": ">=22.8.0"


### PR DESCRIPTION
Aligns staging with the other environments e.g. [Prod](https://github.com/ministryofjustice/cica-apply-web/blob/508511e46815ad4c358e3486149c5716e8b92b52/kube_deploy/Prod/deploy.yml#L87)