### PR TITLE
Update GA4 configuration

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -14,6 +14,7 @@ process.env.CW_LIVECHAT_START_TIMES =
 process.env.CW_LIVECHAT_END_TIMES =
     '23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000,23:59:59.000';
 process.env.CW_URL = 'http://www.b44e2eaa-baf5-47aa-8ac9-5d23ee2a7297.gov.uk';
+process.env.CW_DOMAIN = 'www.b44e2eaa-baf5-47aa-8ac9-5d23ee2a7297.gov.uk';
 process.env.CW_GOVUK_CLIENT_ID = 'thisistheclientid';
 process.env.CW_GOVUK_PRIVATE_KEY = 'thisisthegovukprivatekey';
 process.env.CW_GOVUK_ISSUER_URL = 'http://www.80443328-da85-42de-8a3d-06e1d8f8fcc8.gov.uk';

--- a/kube_deploy/Dev/deploy.yml
+++ b/kube_deploy/Dev/deploy.yml
@@ -32,6 +32,8 @@ spec:
               value: G-2HXYKFX8BH
             - name: CW_URL
               value: https://dev.claim-criminal-injuries-compensation.service.justice.gov.uk
+            - name: CW_DOMAIN
+              value: claim-criminal-injuries-compensation.service.justice.gov.uk
             - name: CW_LIVECHAT_CHAT_ID
               value: ff753a08-883d-453c-bf64-811301587100
             - name: CW_LIVECHAT_ALIVE

--- a/kube_deploy/Prod/deploy.yml
+++ b/kube_deploy/Prod/deploy.yml
@@ -32,6 +32,8 @@ spec:
               value: G-R1EK2KSDKC
             - name: CW_URL
               value: https://claim-criminal-injuries-compensation.service.justice.gov.uk
+            - name: CW_DOMAIN
+              value: claim-criminal-injuries-compensation.service.justice.gov.uk
             - name: CW_LIVECHAT_CHAT_ID
               value: ff753a08-883d-453c-bf64-811301587100
             - name: CW_LIVECHAT_ALIVE

--- a/kube_deploy/Stag/deploy.yml
+++ b/kube_deploy/Stag/deploy.yml
@@ -32,6 +32,8 @@ spec:
               value: UA-136710388-3
             - name: CW_URL
               value: https://stag.claim-criminal-injuries-compensation.service.justice.gov.uk
+            - name: CW_DOMAIN
+              value: claim-criminal-injuries-compensation.service.justice.gov.uk
             - name: CW_LIVECHAT_CHAT_ID
               value: ff753a08-883d-453c-bf64-811301587100
             - name: CW_LIVECHAT_ALIVE

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -32,6 +32,8 @@ spec:
               value: G-HBFPVZ3JHD
             - name: CW_URL
               value: https://uat.claim-criminal-injuries-compensation.service.justice.gov.uk
+            - name: CW_DOMAIN
+              value: claim-criminal-injuries-compensation.service.justice.gov.uk
             - name: CW_LIVECHAT_CHAT_ID
               value: ff753a08-883d-453c-bf64-811301587100
             - name: CW_LIVECHAT_ALIVE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cica-web",
-    "version": "7.5.25",
+    "version": "7.5.26",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "cica-web",
-            "version": "7.5.25",
+            "version": "7.5.26",
             "license": "MIT",
             "dependencies": {
                 "@ministryofjustice/frontend": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cica-web",
-    "version": "7.5.25",
+    "version": "7.5.26",
     "engines": {
         "npm": ">=10.8.2",
         "node": ">=22.8.0"

--- a/page/blank.njk
+++ b/page/blank.njk
@@ -41,8 +41,13 @@
                 dataLayer.push(arguments);
             }
             gtag('js', new Date());
-            gtag('set', {cookie_flags: 'SameSite=Lax;Secure'});
-            gtag('config', '{{ CW_GA_TRACKING_ID }}');
+            gtag('set', {
+                cookie_flags: 'SameSite=Lax;Secure',
+                cookie_domain: '{{ CW_DOMAIN }}'
+            });
+            gtag('config', '{{ CW_GA_TRACKING_ID }}', {
+                'user_id': '{{ userId }}'
+            });
         </script>
 
         {% include "cookie-banner.njk" %}

--- a/page/page.njk
+++ b/page/page.njk
@@ -30,9 +30,12 @@
             dataLayer.push(arguments);
         }
         gtag('js', new Date());
-        gtag('set', {cookie_flags: 'SameSite=Lax;Secure'});
+        gtag('set', {
+            cookie_flags: 'SameSite=Lax;Secure',
+            cookie_domain: '{{ CW_DOMAIN }}'
+        });
         gtag('config', '{{ CW_GA_TRACKING_ID }}', {
-          'user_id': '{{ userId }}'
+            'user_id': '{{ userId }}'
         });
     </script>
 {% endblock %}

--- a/templateEngine/index.js
+++ b/templateEngine/index.js
@@ -36,6 +36,7 @@ function createTemplateEngineService(app) {
             )
             .addGlobal('CW_GA_TRACKING_ID', process.env.CW_GA_TRACKING_ID)
             .addGlobal('CW_URL', process.env.CW_URL)
+            .addGlobal('CW_DOMAIN', process.env.CW_DOMAIN)
             .addGlobal('CW_LIVECHAT_CHAT_ID', process.env.CW_LIVECHAT_CHAT_ID)
             .addGlobal(
                 'CW_LIVECHAT_MAINTENANCE_MESSAGE',

--- a/test/test-fixtures/html/sectionHtmlWithErrors.js
+++ b/test/test-fixtures/html/sectionHtmlWithErrors.js
@@ -1,6 +1,290 @@
 'use strict';
 
-const sectionHtmlWithErrorshtml =
-    '<!DOCTYPE html>\n<html lang="en" class="govuk-template">\n  <head>\n    <meta charset="utf-8">\n    <title>Error: You should not apply again - Claim criminal injuries compensation - GOV.UK\n            </title>\n    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">\n    <meta name="theme-color" content="#0b0c0c">\n\n    \n      <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">\n      <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">\n      <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#0b0c0c">\n      <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">\n      <link rel="manifest" href="/assets/manifest.json">\n    \n\n    \r\n\r\n  <link href="/govuk-frontend/all.css?v=1.2.3&c=Qnefc5ywgazsrupSws1uk" rel="stylesheet"/>\r\n\r\n  <link rel="stylesheet" href="/dist/css/accessible-autocomplete.css?v=1.2.3&c=Qnefc5ywgazsrupSws1uk"/>\r\n  <link rel="stylesheet" href="/dist/css/accessible-autocomplete-wrapper.css?v=1.2.3&c=Qnefc5ywgazsrupSws1uk"/>\r\n\n    \n  </head>\n  <body class="govuk-template__body">\n    <script nonce="vxRGNXkIRC4wZnzoZC_dk">document.body.className += \' js-enabled\' + (\'noModule\' in HTMLScriptElement.prototype ? \' govuk-frontend-supported\' : \'\');</script>\n    \r\n    <!-- Global site tag (gtag.js) - Google Analytics -->\r\n    <script nonce="vxRGNXkIRC4wZnzoZC_dk" async src="https://www.googletagmanager.com/gtag/js?id="></script>\r\n    <script nonce="vxRGNXkIRC4wZnzoZC_dk">\r\n        window.dataLayer = window.dataLayer || [];\r\n        function gtag() {\r\n            dataLayer.push(arguments);\r\n        }\r\n        gtag(\'js\', new Date());\r\n        gtag(\'set\', {cookie_flags: \'SameSite=Lax;Secure\'});\r\n        gtag(\'config\', \'\', {\r\n          \'user_id\': \'\'\r\n        });\r\n    </script>\r\n\n\n    \r\n    \n      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>\n\n    \r\n    \r\n    <div class="cookie-banner govuk-width-container" id="cookie-banner">\r\n    <div class="govuk-grid-row">\r\n        <div class=" govuk-grid-column-two-thirds">\r\n            <div class="cookie-banner__message">\r\n                <h2 class="govuk-heading-m">Tell us whether you accept cookies</h2>\r\n                <p class="govuk-body">This service uses cookies that are essential for the site to work. We also use non-essential cookies to help us improve your experience.</p>\r\n                <p class="govuk-body">Do you accept these non-essential cookies?</p>\r\n            </div>\r\n            <div class="cookie-banner__buttons">\r\n                <div class="cookie-banner__button cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">\r\n                    <a href="/cookies" id="cookie-banner-accept-all" class="govuk-button button--inline" role="button">Accept all cookies</a>\r\n                </div>\r\n                <div class="cookie-banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">\r\n                    <a href="/cookies" id="cookie-banner-set-preferences" class="govuk-button govuk-button--secondary button--inline" role="button">Set cookie preferences</a>\r\n                </div>\r\n            </div>\r\n        </div>\r\n    </div>\r\n</div>\r\n\n\n    \r\n    \r\n        <header class="govuk-header" data-module="govuk-header">\n  <div class="govuk-header__container govuk-width-container">\n    <div class="govuk-header__logo">\n      <a href="https://www.gov.uk" class="govuk-header__link govuk-header__link--homepage">\n        <svg\n          focusable="false"\n          role="img"\n          class="govuk-header__logotype"\n          xmlns="http://www.w3.org/2000/svg"\n          viewBox="0 0 148 30"\n          height="30"\n          width="148"\n          aria-label="GOV.UK"\n        >\n          <title>GOV.UK</title>\n          <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>\n        </svg>\n        \n      </a>\n    </div>\n  \n    <div class="govuk-header__content">\n    \n      \n      <a href="https://www.gov.uk/claim-compensation-criminal-injury/make-claim" class="govuk-header__link govuk-header__service-name">\n        Claim criminal injuries compensation\n      </a>\n      \n    \n    \n    </div>\n  \n  </div>\n</header>\n\r\n    \r\n\r\n    <div class="govuk-width-container" role="navigation">\r\n        \n                <div class="govuk-grid-column-two-thirds">\n                    \n                        \n                        <a href="/apply/previous/info-context-you-should-not-apply-again" class="govuk-back-link">Previous page</a>\n\n                    \n                </div>\n                \n            \r\n    </div>\r\n\n\n    \r\n    \n      <div class="govuk-width-container">\n        \n        <main class="govuk-main-wrapper" id="main-content">\n          \r\n    <div class="govuk-grid-row">\r\n        <div class="govuk-grid-column-two-thirds">\r\n            \r\n\r\n            \n                <form method="post" novalidate autocomplete="off">\n                    \n                        \n              <div class="govuk-error-summary" data-module="govuk-error-summary">\n  <div role="alert">\n    <h2 class="govuk-error-summary__title">\n      There is a problem\n    </h2>\n    <div class="govuk-error-summary__body">\n      \n      <ul class="govuk-list govuk-error-summary__list">\n      \n        <li>\n        \n          <a href="#q--duplicate-application-confirmation">Select that you understand what happens if you apply more than once for injuries related to the same crime</a>\n        \n        </li>\n      \n      </ul>\n    </div>\n  </div>\n</div>\n\n            \n            <h1 class="govuk-heading-xl">You should not apply again</h1>\n            <div id="you-should-not-apply-again"> <p class="govuk-body">If you’ve applied before, or someone’s applied for you, for injuries related to this crime, we cannot accept another application from you.</p> <h2 class="govuk-heading-m">If you’re waiting to hear from us</h2> <p class="govuk-body">We have your application and are processing it. We’ll contact you if we need any more information.</p> <p class="govuk-body">In the majority of cases we make a decision within 12 months, but it can take longer. You may not hear from us during this time, but we are working hard to process your application as quickly as possible.</p><p class="govuk-body">If your information has changed and you need to let us know, you can <a class="govuk-link" href="https://contact-the-cica.form.service.justice.gov.uk/">contact us to update your existing application. </a></p><h2 class="govuk-heading-m">If you applied in the past but were not successful</h2><p class="govuk-body">We cannot accept another application from you, for injuries related to this crime. You should not apply again.</p><p class="govuk-body"> If you want to exit this application, you can close this window or tab. You can still continue, if you would like to.</p></div>\n\n\n\n\n\n<div class="govuk-form-group govuk-form-group--error">\n\n  <p id="q--duplicate-application-confirmation-error" class="govuk-error-message">\n    \n    <span class="govuk-visually-hidden">Error:</span> Select that you understand what happens if you apply more than once for injuries related to the same crime\n    \n  </p>\n\n  <div class="govuk-checkboxes" data-module="govuk-checkboxes">\n    \n    \n      \n  \n  \n    \n    \n    \n    \n    \n    <div class="govuk-checkboxes__item">\n      <input class="govuk-checkboxes__input" id="q--duplicate-application-confirmation" name="q--duplicate-application-confirmation" type="checkbox" value="I understand" aria-describedby="q--duplicate-application-confirmation-error">\n      <label class="govuk-label govuk-checkboxes__label" for="q--duplicate-application-confirmation">\n        I understand that if I apply more than once for injuries related to the same crime, my second application won’t be considered by CICA.\n      </label>\n      \n    </div>\n    \n  \n\n    \n    \n  </div>\n\n</div>\n\n                    \n                            \n                                \n  \n\n  \n    \n  \n\n<button type="submit" data-prevent-double-click="true" class="govuk-button govuk-button--secondary" data-module="govuk-button">\n  Continue anyway\n</button>\n\n                                                   \n                    \n                    <input type="hidden" name="_csrf" value="ihjsOcdp-XAWRzksu5YpE2tczpQzK02VWEKg">\n                <input type="hidden" name="_external-id" value="urn:uuid:ce66be9d-5880-4559-9a93-df15928be396">\n                </form>\n            \r\n        </div>\r\n    </div>\r\n\n        </main>\n      </div>\n    \r\n    <div class="govuk-width-container">\r\n        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">\r\n        <p class="govuk-body-s">\r\n            <a class="govuk-link" href="https://www.surveymonkey.co.uk/r/YourFeedbackPB" target="_blank">Tell us your feedback (opens in new tab)</a> to help us to improve our service.</p>\r\n    </div>\r\n\n\n    \r\n    <footer class="govuk-footer">\n  <div class="govuk-width-container">\n    \n    <div class="govuk-footer__meta">\n      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">\n        \n        <h2 class="govuk-visually-hidden">Support links</h2>\n        \n        <ul class="govuk-footer__inline-list">\n        \n          <li class="govuk-footer__inline-list-item">\n            <a class="govuk-footer__link" href="https://www.gov.uk/guidance/cica-privacy-notice">\n              Privacy\n            </a>\n          </li>\n        \n          <li class="govuk-footer__inline-list-item">\n            <a class="govuk-footer__link" href="/cookies">\n              Cookies\n            </a>\n          </li>\n        \n          <li class="govuk-footer__inline-list-item">\n            <a class="govuk-footer__link" href="/contact-us">\n              Contact\n            </a>\n          </li>\n        \n          <li class="govuk-footer__inline-list-item">\n            <a class="govuk-footer__link" href="/accessibility-statement">\n              Accessibility statement\n            </a>\n          </li>\n        \n        </ul>\n        \n        \n        \n        <svg\n          aria-hidden="true"\n          focusable="false"\n          class="govuk-footer__licence-logo"\n          xmlns="http://www.w3.org/2000/svg"\n          viewBox="0 0 483.2 195.7"\n          height="17"\n          width="41"\n        >\n          <path\n            fill="currentColor"\n            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"\n          />\n        </svg>\n        <span class="govuk-footer__licence-description">\n        \n          All content is available under the\n          <a\n            class="govuk-footer__link"\n            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"\n            rel="license"\n          >Open Government Licence v3.0</a>, except where otherwise stated\n        \n        </span>\n      </div>\n      <div class="govuk-footer__meta-item">\n        <a\n          class="govuk-footer__link govuk-footer__copyright-logo"\n          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"\n        >\n        \n          © Crown copyright\n        \n        </a>\n      </div>\n    </div>\n  </div>\n</footer>\n\r\n\n\n    \r\n    \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n<div class="govuk-modal" id="govuk-modal-session-timing-out" data-module="govuk-modal">\r\n    <div class="govuk-modal__wrapper">\r\n        <dialog\r\n            id="session-timing-out"\r\n            class="govuk-modal__box"\r\n            aria-labelledby="session-timing-out-title"\r\n            aria-describedby="session-timing-out-content"\r\n            aria-modal="true"\r\n            role="alertdialog"\r\n            tabindex="0"\r\n        >\r\n            <div class="govuk-modal__header">\r\n               \r\n                <svg\r\n                    aria-hidden="true"\r\n                    focusable="false"\r\n                    class="govuk-header__logotype-crown govuk-modal__header-image"\r\n                    xmlns="http://www.w3.org/2000/svg"\r\n                    viewBox="0 0 32 30"\r\n                    height="30"\r\n                    width="32"\r\n                >\r\n                <path\r\n                    fill="currentColor" fill-rule="evenodd"\r\n                    d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8"></path>\r\n                </svg>\r\n               \r\n                \r\n            </div>\r\n            <div class="govuk-modal__main">\r\n                \r\n                    <span class="govuk-modal__heading govuk-heading-l" id="session-timing-out-title">\r\n                        \r\n                            \r\n    <span aria-live="assertive">Your session will time out in <span class="govuk-modal__time-remaining" aria-atomic="true" aria-live="assertive"></span></span>\r\n\r\n                        \r\n                    </span>\r\n                \r\n                \r\n                    <div class="govuk-modal__content" id="session-timing-out-content">\r\n                        \r\n                            \r\n    <p class="govuk-body">You\'ll lose your unsaved progress if you don\'t continue. We do this to keep your information secure.</p>\r\n\r\n                        \r\n                    </div>\r\n                \r\n                \r\n                    \r\n    \n  \n\n  \n    \n  \n\n<button type="button" class="govuk-button govuk-modal__continue ga-event--click" data-module="govuk-button"\n    \n        \n      \n    \n        \n      \n    \n   data-tracking-category="modal-button" data-tracking-label="Continue application">\n  Continue application\n</button>\n\r\n\r\n                \r\n            </div>\r\n        </dialog>\r\n    </div>\r\n    <div class="govuk-modal__overlay"></div>\r\n</div>\r\n\r\n\r\n\r\n<div class="govuk-modal" id="govuk-modal-session-ended" data-module="govuk-modal">\r\n    <div class="govuk-modal__wrapper">\r\n        <dialog\r\n            id="session-ended"\r\n            class="govuk-modal__box"\r\n            aria-labelledby="session-ended-title"\r\n            aria-describedby="session-ended-content"\r\n            aria-modal="true"\r\n            role="alertdialog"\r\n            tabindex="0"\r\n        >\r\n            <div class="govuk-modal__header">\r\n               \r\n                <svg\r\n                    aria-hidden="true"\r\n                    focusable="false"\r\n                    class="govuk-header__logotype-crown govuk-modal__header-image"\r\n                    xmlns="http://www.w3.org/2000/svg"\r\n                    viewBox="0 0 32 30"\r\n                    height="30"\r\n                    width="32"\r\n                >\r\n                <path\r\n                    fill="currentColor" fill-rule="evenodd"\r\n                    d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8"></path>\r\n                </svg>\r\n               \r\n                \r\n            </div>\r\n            <div class="govuk-modal__main">\r\n                \r\n                    <span class="govuk-modal__heading govuk-heading-l" id="session-ended-title">\r\n                        \r\n                            \r\n    Your session has timed out\r\n\r\n                        \r\n                    </span>\r\n                \r\n                \r\n                    <div class="govuk-modal__content" id="session-ended-content">\r\n                        \r\n                            \r\n    <p class="govuk-body">Your session has been timed out due to 30 minutes of inactivity. You can sign back in to resume your application if you saved your progress. If not, you\'ll have to start a new application.</p>\r\n\r\n                        \r\n                    </div>\r\n                \r\n                \r\n                    \r\n    \n  \n\n  \n    \n  \n\n<a href="/apply" role="button" draggable="false" class="govuk-button ga-event--click" data-module="govuk-button"\n    \n        \n      \n    \n        \n      \n    \n   data-tracking-category="modal-button" data-tracking-label="Start again">\n  Continue\n</a>\n\r\n\r\n                \r\n            </div>\r\n        </dialog>\r\n    </div>\r\n    <div class="govuk-modal__overlay"></div>\r\n</div>\r\n\r\n\r\n\r\n<div class="govuk-modal" id="govuk-modal-session-resume-error" data-module="govuk-modal">\r\n    <div class="govuk-modal__wrapper">\r\n        <dialog\r\n            id="session-resume-error"\r\n            class="govuk-modal__box"\r\n            aria-labelledby="session-resume-error-title"\r\n            aria-describedby="session-resume-error-content"\r\n            aria-modal="true"\r\n            role="alertdialog"\r\n            tabindex="0"\r\n        >\r\n            <div class="govuk-modal__header">\r\n               \r\n                <svg\r\n                    aria-hidden="true"\r\n                    focusable="false"\r\n                    class="govuk-header__logotype-crown govuk-modal__header-image"\r\n                    xmlns="http://www.w3.org/2000/svg"\r\n                    viewBox="0 0 32 30"\r\n                    height="30"\r\n                    width="32"\r\n                >\r\n                <path\r\n                    fill="currentColor" fill-rule="evenodd"\r\n                    d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8"></path>\r\n                </svg>\r\n               \r\n                \r\n                    \n  \n\n  \n    \n  \n\n<button type="button" class="govuk-button govuk-modal__close" data-module="govuk-button"\n    \n        \n      \n    \n   aria-label="Close modal">\n  ×\n</button>\n\r\n                \r\n            </div>\r\n            <div class="govuk-modal__main">\r\n                \r\n                    <span class="govuk-modal__heading govuk-heading-l" id="session-resume-error-title">\r\n                        \r\n                            \r\n    Something went wrong\r\n\r\n                        \r\n                    </span>\r\n                \r\n                \r\n                    <div class="govuk-modal__content" id="session-resume-error-content">\r\n                        \r\n                            \r\n    <p class="govuk-body">We\'re unable to resume this application. Unless you were signed in and saved your progress, you\'ll have to start your application again.</p>\r\n\r\n                        \r\n                    </div>\r\n                \r\n                \r\n                    \r\n    \n  \n\n  \n    \n  \n\n<a href="/apply" role="button" draggable="false" class="govuk-button ga-event--click" data-module="govuk-button"\n    \n        \n      \n    \n        \n      \n    \n   data-tracking-category="modal-button" data-tracking-label="Start again">\n  Continue\n</a>\n\r\n\r\n                \r\n            </div>\r\n        </dialog>\r\n    </div>\r\n    <div class="govuk-modal__overlay"></div>\r\n</div>\r\n    \r\n    <script nonce="vxRGNXkIRC4wZnzoZC_dk">\r\n        window.CICA = {\r\n            SERVICE_URL: \'http://www.b44e2eaa-baf5-47aa-8ac9-5d23ee2a7297.gov.uk\',\r\n            ANALYTICS_TRACKING_ID: \'\',\r\n            CICA_ANALYTICS_ID: \'urn:uuid:ce66be9d-5880-4559-9a93-df15928be396\'\r\n        };\r\n    </script>\r\n    <script type="module" nonce="vxRGNXkIRC4wZnzoZC_dk">\r\n        import {initAll} from \'/govuk-frontend/all.js?v=1.2.3&c=Qnefc5ywgazsrupSws1uk\'\r\n        initAll();\r\n    </script>\r\n    <script nonce="vxRGNXkIRC4wZnzoZC_dk" src="https://code.jquery.com/jquery-3.6.3.min.js" integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"></script>\r\n    <script nonce="vxRGNXkIRC4wZnzoZC_dk" src="/dist/js/autocomplete.min.js?v=1.2.3&c=Qnefc5ywgazsrupSws1uk"></script>\r\n    <script nonce="vxRGNXkIRC4wZnzoZC_dk" src="/dist/js/bundle.js?v=1.2.3&c=Qnefc5ywgazsrupSws1uk"></script>\r\n\n  </body>\n</html>\n';
+const sectionHtmlWithErrorshtml = `
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+    <head>
+        <meta charset="utf-8">
+        <title>Error: You should not apply again - Claim criminal injuries compensation - GOV.UK </title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="theme-color" content="#0b0c0c">
+        <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+        <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+        <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+        <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+        <link rel="manifest" href="/assets/manifest.json">
+        <link href="/govuk-frontend/all.css?v=1.2.3&c=Qnefc5ywgazsrupSws1uk" rel="stylesheet" />
+        <link rel="stylesheet" href="/dist/css/accessible-autocomplete.css?v=1.2.3&c=Qnefc5ywgazsrupSws1uk" />
+        <link rel="stylesheet" href="/dist/css/accessible-autocomplete-wrapper.css?v=1.2.3&c=Qnefc5ywgazsrupSws1uk" />
+    </head>
+
+    <body class="govuk-template__body">
+        <script nonce="vxRGNXkIRC4wZnzoZC_dk">document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script nonce="vxRGNXkIRC4wZnzoZC_dk" async src="https://www.googletagmanager.com/gtag/js?id="></script>
+        <script nonce="vxRGNXkIRC4wZnzoZC_dk">
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag('js', new Date());
+            gtag('set', {
+                cookie_flags: 'SameSite=Lax;Secure',
+                cookie_domain: 'www.b44e2eaa-baf5-47aa-8ac9-5d23ee2a7297.gov.uk' 
+            });
+            gtag('config', '', {
+                'user_id': ''
+            });
+        </script>
+        <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+        <div class="cookie-banner govuk-width-container" id="cookie-banner">
+            <div class="govuk-grid-row">
+                <div class=" govuk-grid-column-two-thirds">
+                    <div class="cookie-banner__message">
+                        <h2 class="govuk-heading-m">Tell us whether you accept cookies</h2>
+                        <p class="govuk-body">This
+                            service uses cookies that are essential for the site to work. We also use non-essential cookies
+                            to help us improve your experience.</p>
+                        <p class="govuk-body">Do you accept these
+                            non-essential cookies?</p>
+                    </div>
+                    <div class="cookie-banner__buttons">
+                        <div
+                            class="cookie-banner__button cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
+                            <a href="/cookies" id="cookie-banner-accept-all" class="govuk-button button--inline"
+                                role="button">Accept all cookies</a>
+                        </div>
+                        <div
+                            class="cookie-banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
+                            <a href="/cookies" id="cookie-banner-set-preferences"
+                                class="govuk-button govuk-button--secondary button--inline" role="button">Set cookie
+                                preferences</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <header class="govuk-header" data-module="govuk-header">
+            <div class="govuk-header__container govuk-width-container">
+                <div class="govuk-header__logo"> <a href="https://www.gov.uk"
+                        class="govuk-header__link govuk-header__link--homepage"> <svg focusable="false" role="img"
+                            class="govuk-header__logotype" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 148 30"
+                            height="30" width="148" aria-label="GOV.UK">
+                            <title>GOV.UK</title>
+                            <path
+                                d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z">
+                            </path>
+                        </svg> </a> </div>
+                <div class="govuk-header__content"> <a
+                        href="https://www.gov.uk/claim-compensation-criminal-injury/make-claim"
+                        class="govuk-header__link govuk-header__service-name"> Claim criminal injuries compensation </a>
+                </div>
+            </div>
+        </header>
+        <div class="govuk-width-container" role="navigation">
+            <div class="govuk-grid-column-two-thirds">
+                <a href="/apply/previous/info-context-you-should-not-apply-again" class="govuk-back-link">Previous page</a>
+            </div>
+        </div>
+        <div class="govuk-width-container">
+            <main class="govuk-main-wrapper" id="main-content">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-two-thirds">
+                        <form method="post" novalidate autocomplete="off">
+                            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                                <div role="alert">
+                                    <h2 class="govuk-error-summary__title"> There is a problem </h2>
+                                    <div class="govuk-error-summary__body">
+                                        <ul class="govuk-list govuk-error-summary__list">
+                                            <li> <a href="#q--duplicate-application-confirmation">Select that you understand
+                                                    what happens if you apply more than once for injuries related to the
+                                                    same crime</a> </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <h1 class="govuk-heading-xl">You should not apply again</h1>
+                            <div id="you-should-not-apply-again">
+                                <p class="govuk-body">If you’ve applied before, or someone’s applied for you, for injuries
+                                    related to this crime, we cannot accept another application from you.</p>
+                                <h2 class="govuk-heading-m">If you’re waiting to hear from us</h2>
+                                <p class="govuk-body">We have your application and are processing it. We’ll contact you if
+                                    we need any more information.</p>
+                                <p class="govuk-body">In the majority of cases we make a decision within 12 months, but it
+                                    can take longer. You may not hear from us during this time, but we are working hard to
+                                    process your application as quickly as possible.</p>
+                                <p class="govuk-body">If your information has changed and you need to let us know, you can
+                                    <a class="govuk-link"
+                                        href="https://contact-the-cica.form.service.justice.gov.uk/">contact us to update
+                                        your existing application. </a>
+                                </p>
+                                <h2 class="govuk-heading-m">If you applied in the past but were not successful</h2>
+                                <p class="govuk-body">We cannot accept another application from you, for injuries related to
+                                    this crime. You should not apply again.</p>
+                                <p class="govuk-body"> If you want to exit this application, you can close this window or
+                                    tab. You can still continue, if you would like to.</p>
+                            </div>
+                            <div class="govuk-form-group govuk-form-group--error">
+                                <p id="q--duplicate-application-confirmation-error" class="govuk-error-message"> <span
+                                        class="govuk-visually-hidden">Error:</span> Select that you understand what happens
+                                    if you apply more than once for injuries related to the same crime </p>
+                                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                                    <div class="govuk-checkboxes__item"> <input class="govuk-checkboxes__input"
+                                            id="q--duplicate-application-confirmation"
+                                            name="q--duplicate-application-confirmation" type="checkbox"
+                                            value="I understand"
+                                            aria-describedby="q--duplicate-application-confirmation-error"> <label
+                                            class="govuk-label govuk-checkboxes__label"
+                                            for="q--duplicate-application-confirmation"> I understand that if I apply more
+                                            than once for injuries related to the same crime, my second application won’t be
+                                            considered by CICA. </label> </div>
+                                </div>
+                            </div> <button type="submit" data-prevent-double-click="true"
+                                class="govuk-button govuk-button--secondary" data-module="govuk-button"> Continue
+                                anyway</button> <input type="hidden" name="_csrf"
+                                value="ihjsOcdp-XAWRzksu5YpE2tczpQzK02VWEKg"> <input type="hidden" name="_external-id"
+                                value="urn:uuid:ce66be9d-5880-4559-9a93-df15928be396">
+                        </form>
+                    </div>
+                </div>
+            </main>
+        </div>
+        <div class="govuk-width-container">
+            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+            <p class="govuk-body-s">
+                <a class="govuk-link" href="https://www.surveymonkey.co.uk/r/YourFeedbackPB" target="_blank">Tell us your
+                    feedback (opens in new tab)</a> to help us to improve our service.
+            </p>
+        </div>
+        <footer class="govuk-footer">
+            <div class="govuk-width-container">
+                <div class="govuk-footer__meta">
+                    <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                        <h2 class="govuk-visually-hidden">Support links</h2>
+                        <ul class="govuk-footer__inline-list">
+                            <li class="govuk-footer__inline-list-item"> <a class="govuk-footer__link"
+                                    href="https://www.gov.uk/guidance/cica-privacy-notice"> Privacy </a> </li>
+                            <li class="govuk-footer__inline-list-item"> <a class="govuk-footer__link" href="/cookies">
+                                    Cookies </a> </li>
+                            <li class="govuk-footer__inline-list-item"> <a class="govuk-footer__link" href="/contact-us">
+                                    Contact </a> </li>
+                            <li class="govuk-footer__inline-list-item"> <a class="govuk-footer__link"
+                                    href="/accessibility-statement"> Accessibility statement </a> </li>
+                        </ul> <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
+                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                            <path fill="currentColor"
+                                d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                        </svg> <span class="govuk-footer__licence-description"> All content is available under the <a
+                                class="govuk-footer__link"
+                                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                                rel="license">Open Government Licence v3.0</a>, except where otherwise stated </span>
+                    </div>
+                    <div class="govuk-footer__meta-item"> <a class="govuk-footer__link govuk-footer__copyright-logo"
+                            href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
+                            © Crown copyright </a> </div>
+                </div>
+            </div>
+        </footer>
+        <div class="govuk-modal" id="govuk-modal-session-timing-out" data-module="govuk-modal">
+            <div class="govuk-modal__wrapper">
+                <dialog id="session-timing-out" class="govuk-modal__box" aria-labelledby="session-timing-out-title"
+                    aria-describedby="session-timing-out-content" aria-modal="true" role="alertdialog" tabindex="0">
+                    <div class="govuk-modal__header"> <svg aria-hidden="true" focusable="false"
+                            class="govuk-header__logotype-crown govuk-modal__header-image"
+                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 30" height="30" width="32">
+                            <path fill="currentColor" fill-rule="evenodd"
+                                d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8">
+                            </path>
+                        </svg> </div>
+                    <div class="govuk-modal__main"> <span class="govuk-modal__heading govuk-heading-l"
+                            id="session-timing-out-title"> <span aria-live="assertive">Your session will time out in <span
+                                    class="govuk-modal__time-remaining" aria-atomic="true"
+                                    aria-live="assertive"></span></span> </span>
+                        <div class="govuk-modal__content" id="session-timing-out-content">
+                            <p class="govuk-body">
+                                You'll lose your unsaved progress if you don't continue. We do this to keep your
+                                information secure.</p>
+                        </div> <button type="button" class="govuk-button govuk-modal__continue ga-event--click"
+                            data-module="govuk-button" data-tracking-category="modal-button"
+                            data-tracking-label="Continue application"> Continue
+                            application</button>
+                    </div>
+                </dialog>
+            </div>
+            <div class="govuk-modal__overlay">
+            </div>
+        </div>
+        <div class="govuk-modal" id="govuk-modal-session-ended" data-module="govuk-modal">
+            <div class="govuk-modal__wrapper">
+                <dialog id="session-ended" class="govuk-modal__box" aria-labelledby="session-ended-title"
+                    aria-describedby="session-ended-content" aria-modal="true" role="alertdialog" tabindex="0">
+                    <div class="govuk-modal__header"> <svg aria-hidden="true" focusable="false"
+                            class="govuk-header__logotype-crown govuk-modal__header-image"
+                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 30" height="30" width="32">
+                            <path fill="currentColor" fill-rule="evenodd"
+                                d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8">
+                            </path>
+                        </svg> </div>
+                    <div class="govuk-modal__main"> <span class="govuk-modal__heading govuk-heading-l"
+                            id="session-ended-title"> Your session has
+                            timed out </span>
+                        <div class="govuk-modal__content" id="session-ended-content">
+                            <p class="govuk-body">Your session has been timed out due to 30 minutes of inactivity. You
+                                can sign back in to resume your application if you saved your progress. If not, you'll have
+                                to start a new application.</p>
+                        </div> <a href="/apply" role="button" draggable="false" class="govuk-button ga-event--click"
+                            data-module="govuk-button" data-tracking-category="modal-button"
+                            data-tracking-label="Start again"> Continue</a>
+                    </div>
+                </dialog>
+            </div>
+            <div class="govuk-modal__overlay"></div>
+        </div>
+        <div class="govuk-modal" id="govuk-modal-session-resume-error" data-module="govuk-modal">
+            <div class="govuk-modal__wrapper">
+                <dialog id="session-resume-error" class="govuk-modal__box" aria-labelledby="session-resume-error-title"
+                    aria-describedby="session-resume-error-content" aria-modal="true" role="alertdialog" tabindex="0">
+                    <div class="govuk-modal__header">
+                        <svg aria-hidden="true" focusable="false"
+                            class="govuk-header__logotype-crown govuk-modal__header-image"
+                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 30" height="30" width="32">
+                            <path fill="currentColor" fill-rule="evenodd"
+                                d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8">
+                            </path>
+                        </svg> <button type="button" class="govuk-button govuk-modal__close" data-module="govuk-button"
+                            aria-label="Close modal"> ×</button>
+                    </div>
+                    <div class="govuk-modal__main"> <span class="govuk-modal__heading govuk-heading-l"
+                            id="session-resume-error-title"> Something went wrong </span>
+                        <div class="govuk-modal__content" id="session-resume-error-content">
+                            <p class="govuk-body">
+                                We're unable to resume this application. Unless you were signed in and saved your progress,
+                                you'll have to start your application again.</p>
+                        </div> <a href="/apply" role="button" draggable="false" class="govuk-button ga-event--click"
+                            data-module="govuk-button" data-tracking-category="modal-button"
+                            data-tracking-label="Start again"> Continue</a>
+                    </div>
+                </dialog>
+            </div>
+            <div class="govuk-modal__overlay"></div>
+        </div>
+        <script nonce="vxRGNXkIRC4wZnzoZC_dk">
+            window.CICA = {
+                SERVICE_URL: 'http://www.b44e2eaa-baf5-47aa-8ac9-5d23ee2a7297.gov.uk',
+                ANALYTICS_TRACKING_ID: '',
+                CICA_ANALYTICS_ID: 'urn:uuid:ce66be9d-5880-4559-9a93-df15928be396'
+            };
+        </script>
+
+        <script type="module" nonce="vxRGNXkIRC4wZnzoZC_dk">
+            import { initAll } from '/govuk-frontend/all.js?v=1.2.3&c=Qnefc5ywgazsrupSws1uk'
+            initAll();
+        </script>
+
+        <script nonce="vxRGNXkIRC4wZnzoZC_dk" src="https://code.jquery.com/jquery-3.6.3.min.js" integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"></script>
+        <script nonce="vxRGNXkIRC4wZnzoZC_dk" src="/dist/js/autocomplete.min.js?v=1.2.3&c=Qnefc5ywgazsrupSws1uk"></script>
+        <script nonce="vxRGNXkIRC4wZnzoZC_dk" src="/dist/js/bundle.js?v=1.2.3&c=Qnefc5ywgazsrupSws1uk"></script>
+    </body>
+</html>`;
 
 module.exports = sectionHtmlWithErrorshtml;

--- a/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
+++ b/test/test-fixtures/transformations/resolved html/p-applicant-british-citizen-or-eu-national.js
@@ -27,7 +27,10 @@ const html = `<!DOCTYPE html>
             dataLayer.push(arguments);
         }
         gtag('js', new Date());
-        gtag('set', {cookie_flags: 'SameSite=Lax;Secure'});
+        gtag('set', {
+            cookie_flags: 'SameSite=Lax;Secure',
+            cookie_domain: 'www.b44e2eaa-baf5-47aa-8ac9-5d23ee2a7297.gov.uk'
+        });
         gtag('config', '', {
           'user_id': ''
         });

--- a/test/test-fixtures/transformations/resolved html/p-applicant-secondary-button.js
+++ b/test/test-fixtures/transformations/resolved html/p-applicant-secondary-button.js
@@ -27,7 +27,10 @@ const html = `<!DOCTYPE html>
             dataLayer.push(arguments);
         }
         gtag('js', new Date());
-        gtag('set', {cookie_flags: 'SameSite=Lax;Secure'});
+        gtag('set', {
+            cookie_flags: 'SameSite=Lax;Secure',
+            cookie_domain: 'www.b44e2eaa-baf5-47aa-8ac9-5d23ee2a7297.gov.uk'
+        });
         gtag('config', '', {
           'user_id': ''
         });


### PR DESCRIPTION
Adds a `process.env.CW_DOMAIN` environment variable it has been set to the "lowest" common subdomain for all environments: `claim-criminal-injuries-compensation.service.justice.gov.uk.

It previously was defaulting to `justice.gov.uk` which was working for most browsers. _(default GA behaviour is to set the domain to 1 subdomain of the TLD)_. Setting it to our own specific domain has solved the issue. This will not affect GA data collection due to the `CW_DOMAIN` still being a match for each environment, only more specific.

The default behaviour for localhost is for GA to set the domain to `"none"`. Again, this was working in most browsers, but Firefox was complaining. I have explicitly set the `process.env.CW_DOMAIN` on my local environment to `"none"`. You will need to do the same.

As for the specific reason that FF is complaining about ".justice.gov.uk" being invalid, I am not sure at this point.


----
The CSP warning that are present in FF console are also [nothing to be concerned about](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic). 

For example:

> The 'strict-dynamic' source expression specifies that the trust explicitly given to a script present in the markup, by accompanying it with a nonce or a hash, shall be propagated to all the scripts loaded by that root script. At the same time, any allowlist or source expressions such as 'self' or 'unsafe-inline' will be ignored.

So, the warning in FF that reads `Content-Security-Policy: Ignoring “'unsafe-inline'” within script-src: ‘strict-dynamic’ specified` is telling us that for this particular script, that is loading a resource from a file, it is using the `strict-dynamic` directive that implicitly trusts all scripts loaded via that file also. And because this particular script include is using this particular directive in this particular instance, then all the other directive are ignored in this instance.